### PR TITLE
Add JUnit test report to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,13 @@ jobs:
       - name: Run linter
         run: poetry run pre-commit run --all-files --show-diff-on-failure --color always
       - name: Run tests
-        run: poetry run pytest -q
+        run: |
+          mkdir -p reports
+          set -o pipefail
+          poetry run pytest -q --junitxml=reports/junit.xml | tee reports/pytest.txt
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-report
+          path: reports/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ poetry run pytest
 
 ### Test and Lint Reports
 
-Sample output from running pre-commit and pytest is stored in the `reports/`
-directory. These logs are generated in CI and committed for reference.
+Test logs and a JUnit XML report are stored in the `reports/` directory.
+During continuous integration these files are uploaded as an artifact named
+`test-report`.
 


### PR DESCRIPTION
## Summary
- generate a JUnit XML test report in CI
- upload `reports/` as an artifact
- document the new artifact in the README
- ensure the artifact uploads even if tests fail

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml README.md`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848416c79e88329a1c720cf5389e028