### PR TITLE
Add dump test

### DIFF
--- a/reports/precommit.txt
+++ b/reports/precommit.txt
@@ -6,5 +6,5 @@
 [INFO][m Installing environment for https://github.com/astral-sh/ruff-pre-commit.
 [INFO][m Once installed this environment will be reused.
 [INFO][m This may take a few minutes...
-black................................................(no files to check)[46;30mSkipped[m
-ruff.................................................(no files to check)[46;30mSkipped[m
+black....................................................................[42mPassed[m
+ruff.....................................................................[42mPassed[m

--- a/reports/pytest.txt
+++ b/reports/pytest.txt
@@ -1,2 +1,10 @@
-.                                                                        [100%]
-1 passed in 0.50s
+============================= test session starts ==============================
+platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
+rootdir: /workspace/DataDrill
+configfile: pyproject.toml
+collected 2 items
+
+tests/test_core.py .                                                     [ 50%]
+tests/test_dump.py .                                                     [100%]
+
+============================== 2 passed in 0.18s ===============================

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,0 +1,6 @@
+from datadrill.core import sample_dataframe
+
+
+def test_sample_dataframe_dump():
+    df = sample_dataframe()
+    assert df.write_json() == '[{"numbers":1},{"numbers":2},{"numbers":3}]'


### PR DESCRIPTION
## Summary
- add a new test for dumping DataFrame to JSON
- update precommit and pytest reports

## Testing
- `poetry run pre-commit run --files tests/test_dump.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684850289d208329adcb0169cb0b7265