### PR TITLE
Introduce FieldResolver for column prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,25 @@ During continuous integration these files are uploaded as an artifact named
 
 ## Field API Example
 
-Fields are callables that resolve Polars expressions based on an environment. A simple environment contains a `modified` flag which chooses between column namespaces.
+Fields are callables that resolve Polars expressions based on an environment.
+An environment now uses a `FieldResolver` which can prefix column names.
 
 ```python
-from datadrill import Environment, Field, use_modified, sample_dataframe_with_modified
+from datadrill import (
+    Environment,
+    Field,
+    FieldResolver,
+    use_prefix,
+    sample_dataframe_with_modified,
+)
 
-numbers = Field("numbers", "numbers_modified")
-env = Environment(modified=False)
+df = sample_dataframe_with_modified()
+env = Environment(FieldResolver(df.columns))
+numbers = Field("numbers")
 
 # Select the unmodified column
-sample_dataframe_with_modified().select(numbers()(env))
+df.select(numbers()(env))
 
-# Force the modified namespace
-sample_dataframe_with_modified().select(use_modified(numbers())(env))
+# Force the "modified_" prefix
+df.select(use_prefix("modified_")(numbers())(env))
 ```

--- a/src/datadrill/__init__.py
+++ b/src/datadrill/__init__.py
@@ -1,12 +1,20 @@
 """DataDrill package."""
 
 from .core import sample_dataframe, sample_dataframe_with_modified
-from .field import Environment, Field, use_modified
+from .field import (
+    Environment,
+    Field,
+    FieldResolver,
+    get_data,
+    use_prefix,
+)
 
 __all__ = [
     "sample_dataframe",
     "sample_dataframe_with_modified",
     "Environment",
+    "FieldResolver",
     "Field",
-    "use_modified",
+    "get_data",
+    "use_prefix",
 ]

--- a/src/datadrill/core.py
+++ b/src/datadrill/core.py
@@ -11,6 +11,6 @@ def sample_dataframe_with_modified() -> pl.DataFrame:
     return pl.DataFrame(
         {
             "numbers": [1, 2, 3],
-            "numbers_modified": [10, 20, 30],
+            "modified_numbers": [10, 20, 30],
         }
     )

--- a/src/datadrill/field.py
+++ b/src/datadrill/field.py
@@ -1,20 +1,47 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Sequence
 
 import polars as pl
+
+
+@dataclass(frozen=True)
+class FieldResolver:
+    """Resolve column names based on an optional prefix."""
+
+    schema: Sequence[str]
+    prefix: str = ""
+
+    def with_prefix(self, value: str = "") -> "FieldResolver":
+        """Return a copy of the resolver with ``prefix`` set to ``value``."""
+        return FieldResolver(self.schema, value)
+
+    def clear_prefix(self) -> "FieldResolver":
+        """Return a copy of the resolver without a prefix."""
+        return FieldResolver(self.schema)
+
+    def resolve(self, name: str) -> str:
+        """Return the column name taking the prefix into account."""
+        column = f"{self.prefix}{name}"
+        if column not in self.schema:
+            raise KeyError(f"{column} not in schema")
+        return column
 
 
 @dataclass(frozen=True)
 class Environment:
     """Context used when resolving fields."""
 
-    modified: bool = False
+    resolver: FieldResolver
 
-    def with_modified(self, value: bool = True) -> "Environment":
-        """Return a copy of the environment with ``modified`` set to ``value``."""
-        return Environment(modified=value)
+    def with_prefix(self, value: str = "") -> "Environment":
+        """Return a copy of the environment with ``prefix`` set to ``value``."""
+        return Environment(self.resolver.with_prefix(value))
+
+    def clear_prefix(self) -> "Environment":
+        """Return a copy of the environment without a prefix."""
+        return Environment(self.resolver.clear_prefix())
 
 
 Reader = Callable[[Environment], pl.Expr]
@@ -22,25 +49,37 @@ Reader = Callable[[Environment], pl.Expr]
 
 @dataclass(frozen=True)
 class Field:
-    """Representation of a DataFrame column in two namespaces."""
+    """Representation of a DataFrame column."""
 
     name: str
-    modified_name: str | None = None
 
     def __call__(self) -> Reader:
         """Return a reader that resolves the correct column based on the environment."""
 
         def reader(env: Environment) -> pl.Expr:
-            column = self.modified_name if env.modified else self.name
+            column = env.resolver.resolve(self.name)
             return pl.col(column)
 
         return reader
 
 
-def use_modified(reader: Reader) -> Reader:
-    """Force a reader to resolve using the ``modified`` namespace."""
+def use_prefix(prefix: str) -> Callable[[Reader], Reader]:
+    """Force a reader to resolve using ``prefix``."""
 
-    def wrapper(env: Environment) -> pl.Expr:
-        return reader(env.with_modified())
+    def decorator(reader: Reader) -> Reader:
+        def wrapper(env: Environment) -> pl.Expr:
+            return reader(env.with_prefix(prefix))
 
-    return wrapper
+        return wrapper
+
+    return decorator
+
+
+def get_data(name: str) -> Reader:
+    """Return a reader resolving ``name`` using the environment's resolver."""
+
+    def reader(env: Environment) -> pl.Expr:
+        column = env.resolver.resolve(name)
+        return pl.col(column)
+
+    return reader

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,15 +1,16 @@
 from datadrill import (
     Environment,
     Field,
+    FieldResolver,
+    use_prefix,
     sample_dataframe_with_modified,
-    use_modified,
 )
 
 
 def test_field_unmodified():
     df = sample_dataframe_with_modified()
-    numbers = Field("numbers", "numbers_modified")
-    env = Environment(modified=False)
+    env = Environment(FieldResolver(df.columns))
+    numbers = Field("numbers")
 
     result = df.select(numbers()(env))
     assert result["numbers"].to_list() == [1, 2, 3]
@@ -17,17 +18,18 @@ def test_field_unmodified():
 
 def test_field_modified():
     df = sample_dataframe_with_modified()
-    numbers = Field("numbers", "numbers_modified")
-    env = Environment(modified=True)
+    base_env = Environment(FieldResolver(df.columns))
+    env = base_env.with_prefix("modified_")
+    numbers = Field("numbers")
 
     result = df.select(numbers()(env))
-    assert result["numbers_modified"].to_list() == [10, 20, 30]
+    assert result["modified_numbers"].to_list() == [10, 20, 30]
 
 
-def test_use_modified_overrides_env():
+def test_use_prefix_overrides_env():
     df = sample_dataframe_with_modified()
-    numbers = Field("numbers", "numbers_modified")
-    env = Environment(modified=False)
+    env = Environment(FieldResolver(df.columns))
+    numbers = Field("numbers")
 
-    result = df.select(use_modified(numbers())(env))
-    assert result["numbers_modified"].to_list() == [10, 20, 30]
+    result = df.select(use_prefix("modified_")(numbers())(env))
+    assert result["modified_numbers"].to_list() == [10, 20, 30]


### PR DESCRIPTION
## Summary
- add FieldResolver to Environment and new reader helpers
- rename sample modified column to use `modified_` prefix
- update docs and tests for prefix-based field lookup

## Testing
- `poetry run pre-commit run --files README.md src/datadrill/__init__.py src/datadrill/core.py src/datadrill/field.py tests/test_fields.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486ea032a883299efc6f3b0e7e8582