### PR TITLE
Add operator overloads for Field readers

### DIFF
--- a/reports/pytest.txt
+++ b/reports/pytest.txt
@@ -1,2 +1,9 @@
-...                                                                      [100%]
-3 passed in 0.58s
+============================= test session starts ==============================
+platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
+rootdir: /workspace/DataDrill
+configfile: pyproject.toml
+collected 6 items
+
+tests/test_fields.py ......                                              [100%]
+
+============================== 6 passed in 0.23s ===============================

--- a/src/datadrill/__init__.py
+++ b/src/datadrill/__init__.py
@@ -5,6 +5,7 @@ from .field import (
     Environment,
     Field,
     FieldResolver,
+    Reader,
     get_data,
     use_prefix,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "Environment",
     "FieldResolver",
     "Field",
+    "Reader",
     "get_data",
     "use_prefix",
 ]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -33,3 +33,31 @@ def test_use_prefix_overrides_env():
 
     result = df.select(use_prefix("modified_")(numbers())(env))
     assert result["modified_numbers"].to_list() == [10, 20, 30]
+
+
+def test_add_two_fields():
+    df = sample_dataframe_with_modified()
+    env = Environment(FieldResolver(df.columns))
+    numbers = Field("numbers")
+    modified = Field("modified_numbers")
+
+    result = df.select((numbers() + modified())(env))
+    assert result["numbers"].to_list() == [11, 22, 33]
+
+
+def test_add_field_with_prefix():
+    df = sample_dataframe_with_modified()
+    env = Environment(FieldResolver(df.columns))
+    numbers = Field("numbers")
+
+    result = df.select((numbers() + use_prefix("modified_")(numbers()))(env))
+    assert result["numbers"].to_list() == [11, 22, 33]
+
+
+def test_add_scalar():
+    df = sample_dataframe_with_modified()
+    env = Environment(FieldResolver(df.columns))
+    numbers = Field("numbers")
+
+    result = df.select((numbers() + 1)(env))
+    assert result["numbers"].to_list() == [2, 3, 4]


### PR DESCRIPTION
## Summary
- implement `Reader` class supporting Polars operators
- expose `Reader` in the package API
- update `use_prefix` and `get_data` to return `Reader`
- add tests for arithmetic with fields and scalars

## Testing
- `poetry run pre-commit run --files src/datadrill/field.py src/datadrill/__init__.py tests/test_fields.py`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68487c637bb08329999142ca95f09092