### PR TITLE
Continue Rust migration

### DIFF
--- a/reports/cargo_test.txt
+++ b/reports/cargo_test.txt
@@ -1,7 +1,7 @@
 
-running 1 test
-.
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
 
 
 running 0 tests

--- a/reports/pytest.txt
+++ b/reports/pytest.txt
@@ -1,2 +1,12 @@
-................                                                         [100%]
-16 passed in 0.57s
+============================= test session starts ==============================
+platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
+rootdir: /workspace/DataDrill
+configfile: pyproject.toml
+collected 16 items
+
+tests/test_field_function.py ...                                         [ 18%]
+tests/test_fields.py ......                                              [ 56%]
+tests/test_map.py ..                                                     [ 68%]
+tests/test_reader_extras.py .....                                        [100%]
+
+============================== 16 passed in 0.59s ==============================


### PR DESCRIPTION
## Summary
- migrate FieldResolver and Environment structs to Rust
- add Rust tests for FieldResolver and Environment
- update test logs

## Testing
- `poetry run pre-commit run --files rust/src/lib.rs`
- `poetry run pytest`
- `cargo test --manifest-path rust/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b46f60d588329a871c4d0a2c95647