### PR TITLE
Continue Rust migration

### DIFF
--- a/reports/cargo_test.txt
+++ b/reports/cargo_test.txt
@@ -1,16 +1,20 @@
 
-running 9 tests
+running 13 tests
 test tests::add_scalar ... ignored
+test tests::ask_returns_environment ... ok
+test tests::field_modified_with_prefix ... ok
 test tests::field_resolver_resolves_prefixed_columns ... ok
 test tests::field_unmodified ... ok
-test tests::field_modified_with_prefix ... ok
-test tests::map2_basic ... ignored
-test tests::map_single_reader ... ignored
-test tests::sample_dataframe_contains_expected_columns ... ok
-test tests::add_field_with_prefix ... ok
 test tests::add_two_fields ... ok
+test tests::add_field_with_prefix ... ok
+test tests::map2_with_asks ... ignored
+test tests::map_single_reader ... ignored
+test tests::pure_constant_addition ... ignored
+test tests::asks_prefix ... ok
+test tests::sample_dataframe_contains_expected_columns ... ok
+test tests::map2_basic ... ok
 
-test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.01s
+test result: ok. 9 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.01s
 
 
 running 0 tests

--- a/reports/pytest.txt
+++ b/reports/pytest.txt
@@ -1,5 +1,5 @@
 ============================= test session starts ==============================
-platform linux -- Python 3.12.3, pytest-8.4.0, pluggy-1.6.0
+platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
 rootdir: /workspace/DataDrill
 configfile: pyproject.toml
 collected 16 items


### PR DESCRIPTION
## Summary
- add `ask`, `asks` and `pure` helpers in Rust
- update Rust tests and unignore selected cases
- run cargo, pytest and formatting via pre-commit

## Testing
- `poetry run pre-commit run --files rust/src/lib.rs`
- `poetry run pytest`
- `cargo test --manifest-path rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684bd9c568bc8329bcef130d06d1da44