### PR TITLE
Fix ignored tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -556,6 +557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +741,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -1568,6 +1588,7 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-error",
+ "polars-json",
  "polars-parquet",
  "polars-schema",
  "polars-time",
@@ -1582,6 +1603,27 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "polars-json"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b0fdc69f8a20441b4fbc4843d643d0fa12fcef1b6b27608087ef544c5407f0"
+dependencies = [
+ "chrono",
+ "fallible-streaming-iterator",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-error",
+ "polars-utils",
+ "ryu",
+ "simd-json",
+ "streaming-iterator",
 ]
 
 [[package]]
@@ -2135,6 +2177,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2523,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "ahash",
+ "getrandom 0.2.16",
+ "halfbrown",
+ "once_cell",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
 ]
 
 [[package]]
@@ -2881,6 +2960,18 @@ dependencies = [
  "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,4 +6,4 @@ license = "GPL-2.0"
 authors = ["Codex <codex@openai.com>"]
 
 [dependencies]
-polars = { version = "0.48", features = ["lazy"] }
+polars = { version = "0.48", features = ["lazy", "dtype-decimal"] }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -106,7 +106,7 @@ impl Add<i32> for Reader<Expr> {
     type Output = Reader<Expr>;
 
     fn add(self, rhs: i32) -> Self::Output {
-        Reader::new(move |env| self.run(env) + lit(rhs))
+        Reader::new(move |env| self.run(env) + lit(rhs).cast(DataType::Int32))
     }
 }
 
@@ -114,7 +114,7 @@ impl Add<Reader<Expr>> for i32 {
     type Output = Reader<Expr>;
 
     fn add(self, rhs: Reader<Expr>) -> Self::Output {
-        Reader::new(move |env| lit(self) + rhs.run(env))
+        Reader::new(move |env| lit(self).cast(DataType::Int32) + rhs.run(env))
     }
 }
 
@@ -445,7 +445,11 @@ mod tests {
         let expr = map2(|a, b| a + b, numbers.reader(), prefix_len).run(&env);
         let out = df.lazy().select([expr]).collect().unwrap();
         assert_eq!(
-            out.column("numbers").unwrap().i32().unwrap().to_vec(),
+            out.column("modified_numbers")
+                .unwrap()
+                .i32()
+                .unwrap()
+                .to_vec(),
             vec![Some(19), Some(29), Some(39)]
         );
     }


### PR DESCRIPTION
## Summary
- enable Polars decimal dtype
- update map2_with_asks test to expect `modified_numbers`
- regenerate Cargo.lock

## Testing
- `poetry run pre-commit run --files rust/Cargo.toml rust/Cargo.lock rust/src/lib.rs`
- `poetry run pytest -q`
- `cargo test --manifest-path rust/Cargo.toml -- --ignored`


------
https://chatgpt.com/codex/tasks/task_e_684bfc74de4c8329a80988cdc420537b