### PR TITLE
Implement get_data helper in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ from datadrill import (
     Environment,
     Field,
     FieldResolver,
+    get_data,
     use_prefix,
     sample_dataframe_with_modified,
 )
@@ -83,6 +84,9 @@ df.select(use_prefix("modified_")(numbers())(env))
 # Combine fields with arithmetic operators
 modified = Field("modified_numbers")
 df.select((numbers() + modified())(env))
+
+# Access a column without creating a Field
+df.select(get_data("numbers")(env))
 ```
 
 ## Custom Field Functions

--- a/reports/cargo_test.txt
+++ b/reports/cargo_test.txt
@@ -1,23 +1,25 @@
 
-running 16 tests
+running 18 tests
 test tests::ask_returns_environment ... ok
 test tests::asks_prefix ... ok
-test tests::add_two_fields ... ok
 test tests::add_scalar ... ok
+test tests::add_two_fields ... ok
 test tests::add_field_with_prefix ... ok
 test tests::field_resolver_resolves_prefixed_columns ... ok
-test tests::field_function_basic ... ok
-test tests::field_function_with_reader_arg ... ok
 test tests::field_modified_with_prefix ... ok
 test tests::field_unmodified ... ok
-test tests::map2_basic ... ok
+test tests::field_function_basic ... ok
+test tests::get_data_modified_prefix ... ok
+test tests::field_function_with_reader_arg ... ok
+test tests::get_data_unmodified ... ok
 test tests::map2_with_asks ... ok
 test tests::sample_dataframe_contains_expected_columns ... ok
-test tests::pure_constant_addition ... ok
+test tests::map2_basic ... ok
 test tests::map_single_reader ... ok
+test tests::pure_constant_addition ... ok
 test tests::series_function_basic ... ok
 
-test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
 
 
 running 0 tests

--- a/reports/precommit.txt
+++ b/reports/precommit.txt
@@ -1,7 +1,16 @@
-black................................................(no files to check)[46;30mSkipped[m
+black....................................................................[42mPassed[m
 [2m- hook id: black[m
-ruff.................................................(no files to check)[46;30mSkipped[m
+[2m- duration: 0.17s[m
+
+[1mAll done! ✨ 🍰 ✨[0m
+[34m1 file [0mleft unchanged.
+
+ruff.....................................................................[42mPassed[m
 [2m- hook id: ruff[m
+[2m- duration: 0.01s[m
+
+All checks passed!
+
 cargo fmt................................................................[42mPassed[m
 [2m- hook id: cargo-fmt[m
-[2m- duration: 0.21s[m
+[2m- duration: 0.17s[m

--- a/reports/pytest.txt
+++ b/reports/pytest.txt
@@ -2,11 +2,11 @@
 platform linux -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
 rootdir: /workspace/DataDrill
 configfile: pyproject.toml
-collected 16 items
+collected 18 items
 
-tests/test_field_function.py ...                                         [ 18%]
-tests/test_fields.py ......                                              [ 56%]
-tests/test_map.py ..                                                     [ 68%]
+tests/test_field_function.py ...                                         [ 16%]
+tests/test_fields.py ........                                            [ 61%]
+tests/test_map.py ..                                                     [ 72%]
 tests/test_reader_extras.py .....                                        [100%]
 
-============================== 16 passed in 0.81s ==============================
+============================== 18 passed in 0.62s ==============================

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,6 +2,7 @@ from datadrill import (
     Environment,
     Field,
     FieldResolver,
+    get_data,
     use_prefix,
     sample_dataframe_with_modified,
 )
@@ -61,3 +62,19 @@ def test_add_scalar():
 
     result = df.select((numbers() + 1)(env))
     assert result["numbers"].to_list() == [2, 3, 4]
+
+
+def test_get_data_unmodified():
+    df = sample_dataframe_with_modified()
+    env = Environment(FieldResolver(df.columns))
+
+    result = df.select(get_data("numbers")(env))
+    assert result["numbers"].to_list() == [1, 2, 3]
+
+
+def test_get_data_modified_prefix():
+    df = sample_dataframe_with_modified()
+    env = Environment(FieldResolver(df.columns, prefix="modified_"))
+
+    result = df.select(get_data("numbers")(env))
+    assert result["modified_numbers"].to_list() == [10, 20, 30]


### PR DESCRIPTION
## Summary
- implement `get_data` in Rust for parity with Python API
- add Rust and Python tests for the new helper
- document usage of `get_data` in README
- update test and lint reports

## Testing
- `poetry run pre-commit run --files README.md rust/src/lib.rs tests/test_fields.py`
- `poetry run pytest`
- `cargo test --manifest-path rust/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684c5455803c83299c8903f29f425e79