### PR TITLE
Add bitwise ops to Rust reader

### DIFF
--- a/rust/tests/integration.rs
+++ b/rust/tests/integration.rs
@@ -287,6 +287,20 @@ fn neg_field() {
 }
 
 #[test]
+fn bitand_scalar() {
+    let df = sample_dataframe_with_modified();
+    let env = Environment::new(FieldResolver::new(df.get_column_names_str()));
+    let numbers = Field::new("numbers");
+
+    let expr = (numbers.reader() & 1i32).run(&env);
+    let out = df.lazy().select([expr]).collect().unwrap();
+    assert_eq!(
+        out.column("numbers").unwrap().i32().unwrap().to_vec(),
+        vec![Some(1), Some(0), Some(1)]
+    );
+}
+
+#[test]
 fn not_boolean_expression() {
     let df = sample_dataframe_with_modified();
     let env = Environment::new(FieldResolver::new(df.get_column_names_str()));


### PR DESCRIPTION
## Summary
- support `&`, `|`, and `^` for Rust `Reader`
- test bitwise operation

## Testing
- `poetry run pre-commit run --files rust/src/lib.rs rust/tests/integration.rs`
- `poetry run pytest`
- `cargo test --manifest-path rust/Cargo.toml --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684d3d9a931c83299fab29caf5992304